### PR TITLE
Amplification Form updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -24,7 +24,7 @@ body:
       description: Are there any other relevant dates for this request? Please add additional context as needed.
     validations:
       required: false
-- type: dropdown
+  - type: dropdown
     id: request-type
     attributes:
       label: What is the goal of this amplification request?
@@ -34,7 +34,7 @@ body:
         - Solicit feedback
         - Recruit volunteers
         - Other
-- type: dropdown
+  - type: dropdown
     id: audience
     attributes:
       label: What is the intended audiences or audiences for this content?
@@ -51,7 +51,7 @@ body:
         - Plugin community
         - Theme community
         - Agencies/Enterprise
-     validations:
+    validations:
       required: true
   - type: dropdown
     id: platforms
@@ -117,14 +117,14 @@ body:
     id: content
     attributes:
       label: What do you want to amplify?
-      description: Please describe what you are looking to amplify or promote. If you have specific content that you would like to use, please note that here. If you would like additional help, please consult the [#marketing Slack](https://wordpress.slack.com/archives/C0GKJ7TFA).
+      description: Please describe what you are looking to amplify or promote. include as many details as possible. If you have specific content that you would like to use, please note that here. If you would like additional help, please consult the [#marketing Slack](https://wordpress.slack.com/archives/C0GKJ7TFA).
     validations:
       required: true
   - type: input
-    id: link
+    id: links
     attributes:
-      label: Link
-      description: Is there an article, resource or other links that should be shared with this content?
+      label: Links
+      description: Are there any posts, articles, resources or other links that should be shared with this content?
       placeholder: ex. https://wordpress.org/news
     validations:
       required: false
@@ -132,6 +132,6 @@ body:
     id: notes
     attributes:
       label: Any additional notes or details?
-      placeholder: 
+      placeholder:
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -36,6 +36,8 @@ body:
         - Solicit feedback
         - Recruit volunteers
         - Other
+    validations:
+      required: true
   - type: dropdown
     id: audience
     attributes:

--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -116,7 +116,7 @@ body:
         - Other
     validations:
       required: true
-  - type: text
+  - type: input
     id: summary
     attributes:
       label: What do you want to amplify?

--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -7,6 +7,7 @@ assignees:
   - robinwpdeveloper
   - eidolonnight
 body:
+
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -14,7 +14,7 @@ body:
   - type: dropdown
     id: request-type
     attributes:
-      label: What is the goal of this amplification request?  (Select all that apply)
+      label: What is the goal of this amplification request? (select all that apply)
       multiple: true
       options:
         - Inform community/make an announcement (no action necessary)
@@ -26,7 +26,7 @@ body:
   - type: dropdown
     id: audience
     attributes:
-      label: What is the intended audience(s) for this content? (Select all that apply)
+      label: What is the intended audience(s) for this content? (select all that apply)
       multiple: true
       options:
         - Any/All/Don't know
@@ -45,7 +45,7 @@ body:
   - type: dropdown
     id: platforms
     attributes:
-      label: Are there any specific platforms where you would like this to be shared? (Select all that apply)
+      label: Are there any specific platforms where you would like this to be shared? (select all that apply)
       multiple: true
       options:
         - Any/All/Don't know

--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -10,19 +10,56 @@ body:
       value: |
         Need help spreading the news? Let us know what you would like amplified across the WordPress ecosystem.
   - type: input
-    id: date
+    id: deadline
     attributes:
-      label: Important dates and deadlines
-      description: Are there any relevant dates or deadlines for this request? Please note that posts to social platforms are scheduled at least 1-week in advance. For urgent requests, please consult the [#marketing Slack](https://wordpress.slack.com/archives/C0GKJ7TFA).
+      label: Deadline
+      description: Is there a firm deadline for this request? Please note that posts to social platforms are scheduled at least 1-week in advance. For urgent requests, please consult the [#marketing Slack](https://wordpress.slack.com/archives/C0GKJ7TFA).
       placeholder: ex. 24 May 2024
     validations:
       required: false
-  - type: dropdown
-    id: channels
+  - type: textarea
+    id: important-dates
     attributes:
-      label: Where would you like this shared?
+      label: Additional important dates
+      description: Are there any other relevant dates for this request? Please add additional context as needed.
+    validations:
+      required: false
+- type: dropdown
+    id: request-type
+    attributes:
+      label: What is the goal of this amplification request?
       multiple: true
       options:
+        - Inform community/make an announcement (no action necessary)
+        - Solicit feedback
+        - Recruit volunteers
+        - Other
+- type: dropdown
+    id: audience
+    attributes:
+      label: What is the intended audiences or audiences for this content?
+      multiple: true
+      options:
+        - Any/All
+        - General WordPress community
+        - MakeWP community
+        - WordPress users (existing)
+        - WordPress users (new/potential)
+        - Builders/implementers
+        - Developers
+        - Designers
+        - Plugin community
+        - Theme community
+        - Agencies/Enterprise
+     validations:
+      required: true
+  - type: dropdown
+    id: platforms
+    attributes:
+      label: Are there any specific platforms where you would like this to be shared?  
+      multiple: true
+      options:
+        - Any/All
         - Twitter
         - Facebook
         - Instagram
@@ -33,16 +70,16 @@ body:
         - Tumblr
         - Email
         - News
-        - Any/All of the above
+    validations:
+      required: false
   - type: dropdown
     id: campaign
     attributes:
       label: Campaign
       description: Is this amplification request part of an existing WordPress campaign?
-      multiple: false
+      multiple: true
       options:
-        - Other
-        - "#WordPress"
+        - Not part of a campaign
         - "#LearnWP"
         - "#WPDiversity"
         - "#WPOpenverse"
@@ -59,20 +96,20 @@ body:
       description: What MakeWP Team is this request for?
       multiple: true
       options:
-        - "Accessibility Team"
-        - "Community Team"
-        - "Core Team"
-        - "Design Team"
-        - "Documentation Team"
-        - "Hosting Team"
-        - "Marketing Team"
-        - "Meta Team"
-        - "Plugins Team"
-        - "Polyglots Team"
-        - "Support Team"
-        - "Sustainability Team"
-        - "Themes Team"
-        - "Training Team"
+        - Accessibility Team
+        - Community Team
+        - Core Team
+        - Design Team
+        - Documentation Team
+        - Hosting Team
+        - Marketing Team
+        - Meta Team
+        - Plugins Team
+        - Polyglots Team
+        - Support Team
+        - Sustainability Team
+        - Themes Team
+        - Training Team
         - Other
     validations:
       required: true
@@ -80,7 +117,7 @@ body:
     id: content
     attributes:
       label: What do you want to amplify?
-      description: Please describe what you are looking to amplify or promote. If you have specific content written, please note that here. If you would like additional help, please consult the [#marketing Slack](https://wordpress.slack.com/archives/C0GKJ7TFA).
+      description: Please describe what you are looking to amplify or promote. If you have specific content that you would like to use, please note that here. If you would like additional help, please consult the [#marketing Slack](https://wordpress.slack.com/archives/C0GKJ7TFA).
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -116,11 +116,18 @@ body:
         - Other
     validations:
       required: true
+  - type: text
+    id: summary
+    attributes:
+      label: What do you want to amplify?
+      description: Please provide a short, one-sentence summary of your request.
+    validations:
+      required: true
   - type: textarea
     id: content
     attributes:
-      label: What do you want to amplify?
-      description: Please describe what you are looking to amplify or promote. include as many details as possible. If you have specific content that you would like to use, please note that here. If you would like additional help, please consult the [#marketing Slack](https://wordpress.slack.com/archives/C0GKJ7TFA).
+      label: Amplification request details
+      description: Please describe what you are looking to amplify or promote. Include as many details as possible. If you have specific content that you would like to use, please note that here. If you would like additional help, please consult the [#marketing Slack](https://wordpress.slack.com/archives/C0GKJ7TFA).
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -14,7 +14,7 @@ body:
   - type: dropdown
     id: request-type
     attributes:
-      label: What is the goal of this amplification request?
+      label: What is the goal of this amplification request?  (Select all that apply)
       multiple: true
       options:
         - Inform community/make an announcement (no action necessary)
@@ -26,7 +26,7 @@ body:
   - type: dropdown
     id: audience
     attributes:
-      label: What is the intended audiences or audiences for this content?
+      label: What is the intended audience(s) for this content? (Select all that apply)
       multiple: true
       options:
         - Any/All/Don't know
@@ -45,7 +45,7 @@ body:
   - type: dropdown
     id: platforms
     attributes:
-      label: Are there any specific platforms where you would like this to be shared?  
+      label: Are there any specific platforms where you would like this to be shared? (Select all that apply)
       multiple: true
       options:
         - Any/All/Don't know
@@ -81,7 +81,7 @@ body:
     id: make-team
     attributes:
       label: MakeWP Team
-      description: What MakeWP Team is this request for?
+      description: What MakeWP Team is this request for?  (Select all that apply)
       multiple: true
       options:
         - Accessibility Team

--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -49,7 +49,7 @@ body:
       multiple: true
       options:
         - Any/All/Don't know
-        - Twitter
+        - Twitter/X
         - Facebook
         - Instagram
         - Linkedin
@@ -57,8 +57,10 @@ body:
         - Pinterest
         - Tiktok
         - Tumblr
+        - Threads
         - Email
-        - News
+        - This Month in WordPress
+        - WordPress media
     validations:
       required: true
   - type: dropdown
@@ -84,20 +86,28 @@ body:
       description: What MakeWP Team is this request for?  (Select all that apply)
       multiple: true
       options:
-        - Accessibility Team
-        - Community Team
-        - Core Team
-        - Design Team
-        - Documentation Team
-        - Hosting Team
-        - Marketing Team
-        - Meta Team
-        - Plugins Team
-        - Polyglots Team
-        - Support Team
-        - Sustainability Team
-        - Themes Team
-        - Training Team
+        - Accessibility
+        - CLI
+        - Community
+        - Core
+        - Core Performance
+        - Design
+        - Documentation
+        - Hosting
+        - Marketing
+        - Meta
+        - Mobile
+        - Openverse
+        - Photos
+        - Plugins Review
+        - Polyglots
+        - Sustainability
+        - Support
+        - Test
+        - Themes
+        - Tide
+        - Training
+        - TV
         - Other
     validations:
       required: true
@@ -120,7 +130,7 @@ body:
     attributes:
       label: Links
       description: Are there any posts, articles, resources or other links that should be shared with this content? Please provide the link and any context.
-      placeholder: ex. "https://wordpress.org/news - This is a link to the page we want people to go to"
+      placeholder: E.x. "https://wordpress.org/news - This is a link to the page we want people to go to"
     validations:
       required: false
   - type: input
@@ -128,7 +138,7 @@ body:
     attributes:
       label: Deadline
       description: Is there a firm deadline for this request? Posts to social platforms are scheduled at least one week in advance. For urgent requests, please post in the [#marketing Slack](https://wordpress.slack.com/archives/C0GKJ7TFA).
-      placeholder: ex. 24 May 2024
+      placeholder: E.x. 24 May 2024
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -7,7 +7,6 @@ assignees:
   - robinwpdeveloper
   - eidolonnight
 body:
-
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -52,7 +52,7 @@ body:
         - "#WordCamp"
     validations:
       required: false
-        - type: dropdown
+  - type: dropdown
     id: make-team
     attributes:
       label: MakeWP Team

--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -11,21 +11,6 @@ body:
     attributes:
       value: |
         Need help spreading the news? The Marketing team can help amplify MakeWP content across the WordPress ecosystem.
-  - type: input
-    id: deadline
-    attributes:
-      label: Deadline
-      description: Is there a firm deadline for this request? Posts to social platforms are scheduled at least one week in advance. For urgent requests, please post in the [#marketing Slack](https://wordpress.slack.com/archives/C0GKJ7TFA).
-      placeholder: ex. 24 May 2024
-    validations:
-      required: false
-  - type: textarea
-    id: important-dates
-    attributes:
-      label: Additional important dates
-      description: Are there any other relevant dates for this request? Please add additional context as needed.
-    validations:
-      required: false
   - type: dropdown
     id: request-type
     attributes:
@@ -136,6 +121,21 @@ body:
       label: Links
       description: Are there any posts, articles, resources or other links that should be shared with this content? Please provide the link and any context.
       placeholder: ex. "https://wordpress.org/news - This is a link to the page we want people to go to"
+    validations:
+      required: false
+  - type: input
+    id: deadline
+    attributes:
+      label: Deadline
+      description: Is there a firm deadline for this request? Posts to social platforms are scheduled at least one week in advance. For urgent requests, please post in the [#marketing Slack](https://wordpress.slack.com/archives/C0GKJ7TFA).
+      placeholder: ex. 24 May 2024
+    validations:
+      required: false
+  - type: textarea
+    id: important-dates
+    attributes:
+      label: Additional important dates
+      description: Are there any other relevant dates for this request? Please add additional context as needed.
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -3,6 +3,8 @@ description: Request amplification by the Marketing Team to various marketing ch
 title: "[AMPLIFY]: "
 labels: ["amplify"]
 assignees:
+  - sereedmedia
+  - robinwpdeveloper
   - eidolonnight
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -73,7 +73,7 @@ body:
         - Email
         - News
     validations:
-      required: false
+      required: true
   - type: dropdown
     id: campaign
     attributes:
@@ -89,7 +89,7 @@ body:
         - "#WPBriefing"
         - "#WordCamp"
     validations:
-      required: false
+      required: true
   - type: dropdown
     id: make-team
     attributes:
@@ -125,14 +125,14 @@ body:
     id: links
     attributes:
       label: Links
-      description: Are there any posts, articles, resources or other links that should be shared with this content?
-      placeholder: ex. https://wordpress.org/news
+      description: Are there any posts, articles, resources or other links that should be shared with this content? Please provide the link and any context.
+      placeholder: ex. "https://wordpress.org/news - This is a link to the page we want people to go to"
     validations:
       required: false
   - type: textarea
     id: notes
     attributes:
-      label: Any additional notes or details?
+      label: Any additional notes or details? If you marked "Other" above, please provide additional details here.
       placeholder:
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Need help spreading the news? Let us know what you would like amplified across the WordPress ecosystem.
+        Need help spreading the news? The Marketing team can help amplify MakeWP content across the WordPress ecosystem.
   - type: input
     id: deadline
     attributes:
@@ -40,7 +40,7 @@ body:
       label: What is the intended audiences or audiences for this content?
       multiple: true
       options:
-        - Any/All
+        - Any/All/Don't know
         - General WordPress community
         - MakeWP community
         - WordPress users (existing)
@@ -59,7 +59,7 @@ body:
       label: Are there any specific platforms where you would like this to be shared?  
       multiple: true
       options:
-        - Any/All
+        - Any/All/Don't know
         - Twitter
         - Facebook
         - Instagram
@@ -79,7 +79,6 @@ body:
       description: Is this amplification request part of an existing WordPress campaign?
       multiple: true
       options:
-        - Not part of a campaign
         - "#LearnWP"
         - "#WPDiversity"
         - "#WPOpenverse"

--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -15,7 +15,7 @@ body:
     id: deadline
     attributes:
       label: Deadline
-      description: Is there a firm deadline for this request? Please note that posts to social platforms are scheduled at least 1-week in advance. For urgent requests, please consult the [#marketing Slack](https://wordpress.slack.com/archives/C0GKJ7TFA).
+      description: Is there a firm deadline for this request? Posts to social platforms are scheduled at least one week in advance. For urgent requests, please post in the [#marketing Slack](https://wordpress.slack.com/archives/C0GKJ7TFA).
       placeholder: ex. 24 May 2024
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -1,7 +1,7 @@
 name: Request for amplification
 description: Request amplification by the Marketing Team to various marketing channels
 title: "[AMPLIFY]: "
-labels: ["amplify"]
+labels: ["amplification-request"]
 assignees:
   - sereedmedia
   - robinwpdeveloper

--- a/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-amplification-template.yml
@@ -1,5 +1,5 @@
 name: Request for amplification
-description: Request distribution of material by the Marketing Team to various marketing channels
+description: Request amplification by the Marketing Team to various marketing channels
 title: "[AMPLIFY]: "
 labels: ["amplify"]
 assignees:
@@ -12,9 +12,9 @@ body:
   - type: input
     id: date
     attributes:
-      label: Post date
-      description: What is your preferred day and time to post? Please note that posts to social platforms are scheduled at least 1-week in advance. For urgent requests, please consult the [#marketing Slack](https://wordpress.slack.com/archives/C0GKJ7TFA).
-      placeholder: ex. 24 May 2022
+      label: Important dates and deadlines
+      description: Are there any relevant dates or deadlines for this request? Please note that posts to social platforms are scheduled at least 1-week in advance. For urgent requests, please consult the [#marketing Slack](https://wordpress.slack.com/archives/C0GKJ7TFA).
+      placeholder: ex. 24 May 2024
     validations:
       required: false
   - type: dropdown
@@ -51,26 +51,43 @@ body:
         - "#WPBriefing"
         - "#WordCamp"
     validations:
+      required: false
+        - type: dropdown
+    id: make-team
+    attributes:
+      label: MakeWP Team
+      description: What MakeWP Team is this request for?
+      multiple: true
+      options:
+        - "Accessibility Team"
+        - "Community Team"
+        - "Core Team"
+        - "Design Team"
+        - "Documentation Team"
+        - "Hosting Team"
+        - "Marketing Team"
+        - "Meta Team"
+        - "Plugins Team"
+        - "Polyglots Team"
+        - "Support Team"
+        - "Sustainability Team"
+        - "Themes Team"
+        - "Training Team"
+        - Other
+    validations:
       required: true
   - type: textarea
     id: content
     attributes:
-      label: Suggested content
-      description: Using the [WordPress Brand Writing Style Guide](https://make.wordpress.org/marketing/handbook/resources/style-guide-and-brand-book/), craft your suggested content for this post. The team will review and edit as-needed prior to posting. If you would like additional help, please consult the [#marketing Slack](https://wordpress.slack.com/archives/C0GKJ7TFA).
+      label: What do you want to amplify?
+      description: Please describe what you are looking to amplify or promote. If you have specific content written, please note that here. If you would like additional help, please consult the [#marketing Slack](https://wordpress.slack.com/archives/C0GKJ7TFA).
     validations:
       required: true
-  - type: checkboxes
-    id: onbrand
-    attributes:
-      label: Style confirmation
-      options:
-        - label: I've read the WordPress Brand Writing Style Guide
-          required: true
   - type: input
     id: link
     attributes:
       label: Link
-      description: Do you have an article or resource that should be shared with this content?
+      description: Is there an article, resource or other links that should be shared with this content?
       placeholder: ex. https://wordpress.org/news
     validations:
       required: false


### PR DESCRIPTION
I've modified the Amplification Form per the discussion held during the Marketing team collaboration session .

The intention of this update is to revise the Amplification Form to provide a simple way for MakeWP community members to request amplification. This form is meant primarily for non-Marketing team members and will be the first step in the three-step amplification process.

1. MakeWP community members requests amplification (this form)
2. Marketing team members work on request 
3. Marketing team keyholders review/edit, finalize, and schedule amplification. 