### PR TITLE
Fix broken Markdown link syntax in support.md

### DIFF
--- a/.github/support.md
+++ b/.github/support.md
@@ -1,5 +1,5 @@
 # Support resources
 
-Documentation for the Marketing Team can be found in the [handbook] https://make.wordpress.org/marketing/handbook/about/), and questions are best directed to the [#marketing Slack channel](https://wordpress.slack.com/archives/C0GKJ7TFA).
+Documentation for the Marketing Team can be found in the [handbook](https://make.wordpress.org/marketing/handbook/about/), and questions are best directed to the [#marketing Slack channel](https://wordpress.slack.com/archives/C0GKJ7TFA).
 
 Other teams and support can be found on [make.wordpress.org](https://make.wordpress.org/).


### PR DESCRIPTION
## What
This PR fixes a minor Markdown syntax error in the `support.md` file where the handbook link had incorrect formatting.

## Changes Made
- **Fixed broken link syntax:** Changed `[handbook] https://make.wordpress.org/marketing/handbook/about/)` to `[handbook](https://make.wordpress.org/marketing/handbook/about/)` in the first paragraph.

## Impact
- The link now renders correctly in all Markdown viewers
- No changes to content, other links, or overall structure
- Maintains backward compatibility

This is a straightforward fix that improves the reliability of the documentation.